### PR TITLE
locationrequestの不具合を修正

### DIFF
--- a/KobeARStampApp.xcodeproj/project.pbxproj
+++ b/KobeARStampApp.xcodeproj/project.pbxproj
@@ -29,9 +29,22 @@
 		681502EC2E0E5267000DCB1E /* KobeARStampAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KobeARStampAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		68BFED4B2E7907AD00BCCB10 /* Exceptions for "KobeARStampApp" folder in "KobeARStampApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 681502D12E0E5264000DCB1E /* KobeARStampApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		681502D42E0E5264000DCB1E /* KobeARStampApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				68BFED4B2E7907AD00BCCB10 /* Exceptions for "KobeARStampApp" folder in "KobeARStampApp" target */,
+			);
 			path = KobeARStampApp;
 			sourceTree = "<group>";
 		};
@@ -396,6 +409,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KobeARStampApp/Preview Content\"";
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -424,6 +438,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"KobeARStampApp/Preview Content\"";
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -450,6 +465,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MARKETING_VERSION = 1.0;
@@ -468,6 +484,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MARKETING_VERSION = 1.0;
@@ -485,9 +502,11 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gmail.16bonx2.KobeARStampAppUITests;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.gmail.16bonx2.KobeARStampAppUITests2-";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -501,9 +520,11 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MS4YPZA3C4;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gmail.16bonx2.KobeARStampAppUITests;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.gmail.16bonx2.KobeARStampAppUITests2-";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;

--- a/KobeARStampApp/Info.plist
+++ b/KobeARStampApp/Info.plist
@@ -2,15 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>バックグラウンドで位置情報を取得します。</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>位置情報を常に利用します。</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>位置情報をアプリの使用中に利用します。</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>location</string>
-	</array>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>現在地を地図上に表示するために位置情報を使用します。</string>
 </dict>
 </plist>

--- a/KobeARStampApp/Models/Location/LocationManagerModel.swift
+++ b/KobeARStampApp/Models/Location/LocationManagerModel.swift
@@ -9,55 +9,73 @@ import Foundation
 import CoreLocation
 
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
-    static let shared = LocationManager() // シングルトンインスタンス
+    static let shared = LocationManager()
     
     @Published var latitude: Double = 0.0
     @Published var longitude: Double = 0.0
-    //@Published var locationError: LocationError?
+    
     private var locationContinuation: CheckedContinuation<Void, Never>?
     private var locationManager = CLLocationManager()
     
     private override init() {
         super.init()
         locationManager.delegate = self
-        locationManager.requestAlwaysAuthorization()
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 10
+        
+        // アプリ起動時に自動で許可をリクエスト
+        requestLocationPermission()
     }
     
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        DispatchQueue.global(qos: .background).async {
-            if CLLocationManager.locationServicesEnabled() {
-                DispatchQueue.main.async {
-                    self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
-                    self.locationManager.distanceFilter = 10
-                    self.locationManager.allowsBackgroundLocationUpdates = true
-                    self.locationManager.pausesLocationUpdatesAutomatically = false
-                    self.locationManager.startUpdatingLocation()
-                }
-            } else {
-//                // 位置情報が無効ならエラーをセット
-//                DispatchQueue.main.async {
-//                    self.locationError = .locationServicesDisabled
-//                }
-            }
+    private func requestLocationPermission() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse, .authorizedAlways:
+            startLocationUpdates()
+        case .denied, .restricted:
+            print("位置情報の使用が拒否されています")
+        @unknown default:
+            break
         }
     }
     
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            startLocationUpdates()
+        case .denied, .restricted:
+            print("位置情報の使用が拒否されました")
+        case .notDetermined:
+            break
+        @unknown default:
+            break
+        }
+    }
+    
+    private func startLocationUpdates() {
+        guard CLLocationManager.locationServicesEnabled() else { return }
+        locationManager.startUpdatingLocation()
+    }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let newLocation = locations.last else { return }
         DispatchQueue.main.async {
             self.latitude = newLocation.coordinate.latitude
             self.longitude = newLocation.coordinate.longitude
-            self.locationContinuation?.resume() // 位置情報取得完了を通知
+            self.locationContinuation?.resume()
             self.locationContinuation = nil
         }
     }
     
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("位置情報の取得に失敗: \(error.localizedDescription)")
+    }
+    
     func requestLocationPermissionIfNeeded() async {
-        guard latitude == 0.0 && longitude == 0.0 else { return } // 既に取得済みの場合はスキップ
+        guard latitude == 0.0 && longitude == 0.0 else { return }
         await withCheckedContinuation { continuation in
             self.locationContinuation = continuation
         }
     }
 }
-

--- a/KobeARStampApp/ViewModels/MapViewModel.swift
+++ b/KobeARStampApp/ViewModels/MapViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import  MapKit
+import MapKit
 import Combine
 
 class MapViewModel: ObservableObject {
@@ -19,22 +19,18 @@ class MapViewModel: ObservableObject {
     
     private var cancellables = Set<AnyCancellable>()
     private let locationManager = LocationManager.shared
-    private var didSetCenter = false 
+    private var didSetCenter = false
         
-        init() {
-            locationManager.$latitude
-                .combineLatest(locationManager.$longitude)
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] (lat: Double, lon: Double) in
-                    guard lat != 0.0, lon != 0.0 else { return }
-                    guard let self = self, !self.didSetCenter else { return }
-                    self.centerCoordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)
-                    self.didSetCenter = true
-                }
-                .store(in: &cancellables)
-        }
-    
-    func requestPermission() async {
-        await locationManager.requestLocationPermissionIfNeeded()
+    init() {
+        locationManager.$latitude
+            .combineLatest(locationManager.$longitude)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (lat: Double, lon: Double) in
+                guard lat != 0.0, lon != 0.0 else { return }
+                guard let self = self, !self.didSetCenter else { return }
+                self.centerCoordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+                self.didSetCenter = true
+            }
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## 概要
インストール時に位置情報が取れない問題を削除しました。

## 変更内容
LocationManager.swift

init()内で自動的に位置情報許可をリクエスト
バックグラウンド位置情報（Always許可）関連のコードを削除してシンプル化

MapViewModel.swift

requestPermission()メソッドを削除（LocationManagerが自動処理するため不要）

Info.plist

NSLocationWhenInUseUsageDescriptionのみ残し、Always許可関連の設定を削除

動作変更

アプリ起動時に自動で位置情報許可ダイアログ表示（一般的な地図アプリと同様の動作）